### PR TITLE
Moforemmanuel

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,11 @@ This project was generated with [Angular CLI](https://github.com/angular/angular
 
 ## Development server
 
-Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
+<!-- Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files. -->
+
+Run `ng serve --open` to start the dev server, which automatically opens in your default browser, or run `ng serve` and navigate to `https://localhost:4200/`. 
+
+Then navigate to `http://localhost:4200/dashboard/home`. The app will automatically reload if you change any of the source files.
 
 ## Code scaffolding
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "bootstrap": "^5.1.3",
     "bootstrap-icons": "^1.8.2",
     "jquery": "^3.6.0",
+    "ngx-bootstrap": "^8.0.0",
     "popper.js": "^1.16.1",
     "primeflex": "^3.2.0",
     "primeicons": "^5.0.0",

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,7 +9,6 @@ import {RcClasslistsComponent} from "./modules/rc-dashboard/components/rc-classl
 import {HomeComponent} from './modules/rc-auth/components/home/home.component';
 
 const routes: Routes = [
-  { path: '', redirectTo: '/dashboard/home', pathMatch: 'full'},
   {
     component: DashboardComponent,
     path: 'dashboard',

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -9,6 +9,7 @@ import {RcClasslistsComponent} from "./modules/rc-dashboard/components/rc-classl
 import {HomeComponent} from './modules/rc-auth/components/home/home.component';
 
 const routes: Routes = [
+  { path: '', redirectTo: '/dashboard/home', pathMatch: 'full'},
   {
     component: DashboardComponent,
     path: 'dashboard',

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -35,3 +35,9 @@ body {
 }
 
  */
+
+/* Importing Bootstrap SCSS file. */
+@import "~bootstrap/scss/bootstrap";
+
+/* Importing Datepicker SCSS file. */
+@import "node_modules/ngx-bootstrap/datepicker/bs-datepicker";


### PR DESCRIPTION
Fixes #12 

I added `ngx-boostrap`, solving the error of  running `npm install` preceded by cloning the repo, which then updates the import path of the Datepicker.
I also added navigation guide to the dashboard homepage in the README, because the index `http://localhost:4200/` returns a blank page.